### PR TITLE
feat (priority): Implement and test priority based scheduling

### DIFF
--- a/Inc/kernel.h
+++ b/Inc/kernel.h
@@ -13,12 +13,16 @@ typedef struct {
 
 	/* Timeout variable to keep track of how long a thread should stay blocked */
 	uint32_t timeout;
+
+	/* Thread priority property */
+	uint8_t priority;
 }tcb_type;
 
 /* Function pointer needed to pass in the address of the respective threads */
 typedef void (*tcb_type_handler)();
 
 void kernel_initialize(void);
+void kernel_scheduler_priority_based(void);
 void kernel_scheduler_round_robin(void);
 void kernel_run(void);
 void kernel_tcb_block(uint32_t blocking_timeout);
@@ -27,6 +31,7 @@ void kernel_tcb_permit(void);
 /* Function to start a thread, the void* stack_array variable is the address to the start of the stack in memory */
 void kernel_tcb_start(
 	tcb_type* me,
+	uint8_t priority,
 	tcb_type_handler tcb_handler,
 	void* stack_array,
 	uint32_t stack_size);

--- a/Src/main.c
+++ b/Src/main.c
@@ -8,10 +8,12 @@ tcb_type blinky1;
 void main_blinky1(void)
 {
 	while (1) {
-		led_red_toggle();
-		kernel_tcb_block(500);
-		led_red_toggle();
-		kernel_tcb_block(300);
+		uint32_t volatile i;
+		for (i = 0U; i < 1500U; i++) {
+			led_red_toggle();
+			led_red_toggle();
+		}
+		kernel_tcb_block(20U);	/* Block for 1 tick, 1ms */
 	}
 }
 
@@ -20,14 +22,17 @@ tcb_type blinky2;
 void main_blinky2(void)
 {
 	while (1) {
-		led_orange_toggle();
-		kernel_tcb_block(200);
-		led_orange_toggle();
-		kernel_tcb_block(400);
+		uint32_t volatile i;
+		for (i = 0U; i < 3 * 1500U; i++) {
+			led_orange_toggle();
+			led_orange_toggle();
+		}
+		kernel_tcb_block(50U);	 /* Block for 50 ticks, 50ms */
+
 	}
 }
 
-uint32_t blinky3_stack[40];
+/*uint32_t blinky3_stack[40];
 tcb_type blinky3;
 void main_blinky3(void)
 {
@@ -37,7 +42,7 @@ void main_blinky3(void)
 		led_blue_toggle();
 		kernel_tcb_block(600);
 	}
-}
+}*/
 
 int main (void)
 {
@@ -50,21 +55,23 @@ int main (void)
 
 	kernel_tcb_start(
 		&blinky1,
+		5U,
 		&main_blinky1,
 		blinky1_stack,
 		sizeof(blinky1_stack));
 
 	kernel_tcb_start(
 		&blinky2,
+		2U,
 		&main_blinky2,
 		blinky2_stack,
 		sizeof(blinky2_stack));
 
-	kernel_tcb_start(
+/*	kernel_tcb_start(
 		&blinky3,
 		&main_blinky3,
 		blinky3_stack,
-		sizeof(blinky3_stack));
+		sizeof(blinky3_stack));*/
 
 	/* This start function replaces the redundant superloop */
 	kernel_run();

--- a/Src/systick.c
+++ b/Src/systick.c
@@ -35,7 +35,7 @@ void systick_initialize(void)
 
 void SysTick_Handler(void)
 {
-	led_green_toggle();
+	led_blue_toggle();
 
 	/* Doesn't need to run inside of a critical section because an interrupt cannot be pre-empted by a thread.
 	 * This means no thread will be able to possibly modify the values of the kernel_tcbs[] while this runs
@@ -44,10 +44,10 @@ void SysTick_Handler(void)
 
 	/* Remember the scheduler needs to be called inside of a critical section to avoid race conditions */
 	__disable_irq();
-	kernel_scheduler_round_robin();
+	kernel_scheduler_priority_based();
 	__enable_irq();
 
-	led_green_toggle();
+	led_blue_toggle();
 }
 
 void systick_delay_ms(uint32_t delay)

--- a/rtos_from_scratch.launch
+++ b/rtos_from_scratch.launch
@@ -80,5 +80,5 @@
     </listAttribute>
     <stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&lt;memoryBlockExpressionList context=&quot;reserved-for-future-use&quot;/&gt;"/>
     <stringAttribute key="process_factory_id" value="com.st.stm32cube.ide.mcu.debug.launch.HardwareDebugProcessFactory"/>
-    <stringAttribute key="saved_expressions&lt;seperator&gt;Unknown" value="0x20000078,0x200000c4,0x20000080"/>
+    <stringAttribute key="saved_expressions&lt;seperator&gt;Unknown" value="0x20000078,0x200000c4,0x20000080,0x200001c0"/>
 </launchConfiguration>


### PR DESCRIPTION
The priority based scheduling required refactoring of the kernel file and logic behind some of the functions. Mainly, adding the priority member to the struct tcb_type meant we would now have to use that priority throughout the logic.

The important steps will be covered below:
1) First, changing the function prototypes for the kernel_tcb_start()
   function to include the priority and making sure to set the priority
   for the thread itself. As well as using the priority attribute to set
   the kernel_tcbs_ready_mask bit.

2) Next, the new bitmask uint32_t kernel_tcbs_delayed_mask was added to
   keep track of the blocked threads. This is because using just a
   single bitmask would be inefficient because we would have to loop
   through possibly big increments and jumps in the tcbs_array. Remember
   we are now arranging the locations in the array with priority, not
   sequentially like in round robin.

3) The kernel_scheduler_priority_based() was added to separate out the
   logic from the round robin scheduler.

4) The kernel_tcb_block() and kernel_tcb_permit() functions were also
   modified to use the priority based logic.

5) Finally, the logic analyzer was used to test the priority based
   scheduling. The analyzer confirms blinky1 with the highest priority
   always meets its deadlines and it preempts all other threads that are
   running.